### PR TITLE
docs: update sphinx, add docs build to Travis, minor improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,22 @@
 dist: xenial
 language: python
 python: 3.7
-install:
-  - pip install -U .[style]
-script:
-  - python -m compileall ./
-  - black --check ./
+jobs:
+  include:
+    - stage: "Tests"
+      name: "Compile all"
+      script:
+        - pip install -U .
+        - python -m compileall ./
+    - name: "Style check"
+      script:
+        - pip install -U .[style]
+        - black --check ./
+    - name: "Build docs"
+      script:
+        - pip install -U .[docs]
+        - sphinx-build docs docs/_build/html -W -b html
+        - sphinx-build docs docs/_build/linkcheck -W -b linkcheck
 cache: pip
 deploy:
   provider: pypi

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -98,3 +98,4 @@ The following exceptions are thrown by the library.
 
 .. automodule:: rlapi.errors
     :members:
+    :show-inheritance:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -21,63 +21,13 @@ Enumerations
 The API provides some enumerations for certain types of string to avoid the API
 from being stringly typed in case the strings change in the future.
 
-All enumerations are subclasses of `enum`_.
+All enumerations are subclasses of `enum.Enum`.
 
-.. _enum: https://docs.python.org/3/library/enum.html
+.. autoclass:: rlapi.PlaylistKey
+    :members:
 
-.. class:: rlapi.PlaylistKey
-
-    Represents playlist's key.
-
-    .. container:: operations
-
-        ``str(x)``
-            Returns playlist's friendly name, e.g. "Solo Standard"
-
-    .. attribute:: solo_duel
-
-        The Solo Duel playlist.
-    .. attribute:: doubles
-
-        The Doubles playlist.
-    .. attribute:: solo_standard
-
-        The Solo Standard playlist.
-    .. attribute:: standard
-
-        The Standard playlist.
-    .. attribute:: hoops
-
-        The Hoops playlist.
-    .. attribute:: rumble
-
-        The Rumble playlist.
-    .. attribute:: dropshot
-
-        The Dropshot playlist.
-    .. attribute:: snow_day
-
-        The Snow Day playlist.
-
-.. class:: rlapi.Platform
-
-    Specifies :class:`rlapi.Player`'s platform.
-
-    .. container:: operations
-
-        ``str(x)``
-            Returns platform's friendly name, e.g. "Xbox One"
-
-    .. attribute:: steam
-
-        Steam platform.
-    .. attribute:: ps4
-
-        Playstation 4 platform.
-    .. attribute:: xboxone
-
-        Xbox One platform.
-
+.. autoclass:: rlapi.Platform
+    :members:
 
 Rocket League API Models
 ------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
-    "sphinxcontrib.asyncio",
+    "sphinxcontrib_trio",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,10 +3,6 @@
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
 # http://www.sphinx-doc.org/en/master/config
-import os
-import sys
-
-sys.path.insert(0, os.path.abspath(".."))
 
 # -- Path setup --------------------------------------------------------------
 
@@ -14,9 +10,10 @@ sys.path.insert(0, os.path.abspath(".."))
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(".."))
 
 
 # -- Project information -----------------------------------------------------
@@ -95,6 +92,10 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "aiohttp": ("https://docs.aiohttp.org/en/stable/", None),
 }
+
+# autodoc
+autodoc_member_order = "bysource"
+autodoc_typehints = "none"
 
 
 def setup(app):

--- a/rlapi/enums.py
+++ b/rlapi/enums.py
@@ -4,17 +4,29 @@ __all__ = ("PlaylistKey", "Platform")
 
 
 class PlaylistKey(Enum):
-    """
-    Represents playlist's key.
+    """Represents playlist's key.
+
+    .. container:: operations
+
+        ``str(x)``
+            Returns playlist's friendly name, e.g. "Solo Standard"
     """
 
+    #: The Solo Duel playlist.
     solo_duel = 10
+    #: The Doubles playlist.
     doubles = 11
+    #: The Solo Standard playlist.
     solo_standard = 12
+    #: The Standard playlist.
     standard = 13
+    #: The Hoops playlist.
     hoops = 27
+    #: The Rumble playlist.
     rumble = 28
+    #: The Dropshot playlist.
     dropshot = 29
+    #: The Snow Day playlist.
     snow_day = 30
 
     def __str__(self) -> str:
@@ -23,10 +35,19 @@ class PlaylistKey(Enum):
 
 
 class Platform(Enum):
-    """Represents platform name."""
+    """Represents platform name.
 
+    .. container:: operations
+
+        ``str(x)``
+            Returns platform's friendly name, e.g. "Xbox One"
+    """
+
+    #: The Steam platform.
     steam = "Steam"
+    #: The Playstation 4 platform.
     ps4 = "Playstation 4"
+    #: The Xbox One platform.
     xboxone = "Xbox One"
 
     def __str__(self) -> str:

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,8 +34,8 @@ install_requires =
 
 [options.extras_require]
 docs =
-    sphinx>=2.0.0,<2.1.0
-    sphinxcontrib-asyncio==0.2.0
+    sphinx>=2.1.2,<2.2.0
+    sphinxcontrib-trio==1.1.0
     sphinx_rtd_theme>=0.4.3,<0.5.0
 style =
     black==19.3b0


### PR DESCRIPTION
- update Sphinx to version ~2.1.2
- use sphinxcontrib-trio (==1.1.0) instead of sphinxcontrib-asyncio
- show inheritance for rlapi's exceptions
- disable type hints in function signatures
- put enumerations docs in docstrings to keep all code documentation in code not rst files
- add docs build to Travis configuration (+ split rest of the commands ran by Travis in separate jobs)

Resolves #4