### PR TITLE
docs: hide class signatures for data models

### DIFF
--- a/rlapi/player.py
+++ b/rlapi/player.py
@@ -32,7 +32,7 @@ __all__ = ("Playlist", "SeasonRewards", "Player")
 
 
 class Playlist:
-    """
+    """Playlist()
     Represents Rocket League playlist stats data.
 
     .. container:: operations
@@ -105,7 +105,7 @@ class Playlist:
 
 
 class SeasonRewards:
-    """
+    """SeasonRewards()
     Represents season rewards informations.
 
     Attributes
@@ -137,7 +137,7 @@ class SeasonRewards:
 
 
 class Player:
-    """
+    """Player()
     Represents Rocket League Player
 
     Attributes

--- a/rlapi/tier_estimates.py
+++ b/rlapi/tier_estimates.py
@@ -12,7 +12,7 @@ __all__ = ("TierEstimates",)
 
 
 class TierEstimates:
-    """
+    """TierEstimates()
     Represents Rocket League playlist's tier estimates.
 
     Attributes


### PR DESCRIPTION
Those classes are not meant to be created by a user so docs shouldn't show how to construct them.