### PR TITLE
build: update version requirements for dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,9 +33,9 @@ include_package_data = True
 packages = find_namespace:
 python_requires = >=3.7
 install_requires =
-    aiohttp>=3.5.4,<3.6.0
-    lxml>=4.4.2,<4.5.0
-    typing_extensions==3.7.4; python_version == "3.7"
+    aiohttp>=3.5.4,<3.7.0
+    lxml>=4.4.2,<4.6.0
+    typing_extensions>=3.7.4; python_version == "3.7"
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
Allow lib users to install `aiohttp` 3.6.x and `lxml` 4.5.x.
Change `typing_extensions` req to only specify minimum version.