### PR TITLE
feat: migrate to the new Rocket League API

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 
-> **Rocket League API is currently in closed beta and Psyonix doesn't give out keys easily.**
+> **Rocket League API is currently in closed beta and Psyonix doesn't give out access to it easily.**
 >
 > To request API access, you should contact Psyonix by email RLPublicAPI@psyonix.com and hope for positive response.
 
@@ -32,13 +32,16 @@ To install the development version, replace `rlapi` with `git+https://github.com
 You can easily create a client using the class `Client`. Here's simple example showing how you can get player stats with this library:
 ```py
 import asyncio
+
 import rlapi
 
 
-loop = asyncio.get_event_loop()
+async def main():
+    client = rlapi.Client(client_id="client id", client_secret="client secret")
+    players = await client.get_player("kuxir97", None)
 
-client = rlapi.Client("token")
-players = loop.run_until_complete(client.get_player("kuxir97", None))
+
+asyncio.run(main())
 ```
 
 ## Documentation

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -33,10 +33,13 @@ Here's simple example showing how you can get player stats with this library:
 .. code-block:: python3
 
     import asyncio
+
     import rlapi
 
 
-    loop = asyncio.get_event_loop()
+    async def main():
+        client = rlapi.Client(client_id="client id", client_secret="client secret")
+        players = await client.get_player("kuxir97", None)
 
-    client = rlapi.Client("token")
-    players = loop.run_until_complete(client.get_player("kuxir97", None))
+
+    asyncio.run(main())

--- a/rlapi/_utils.py
+++ b/rlapi/_utils.py
@@ -14,7 +14,7 @@
 
 import json
 import sys
-from typing import Any
+from typing import Any, NamedTuple
 
 import aiohttp
 
@@ -24,9 +24,15 @@ else:
     from typing_extensions import Literal
 
 __all__ = (
+    "TokenInfo",
     "AlwaysGreaterOrEqual",
     "json_or_text",
 )
+
+
+class TokenInfo(NamedTuple):
+    access_token: str
+    expires_at: int
 
 
 class AlwaysGreaterOrEqual:

--- a/rlapi/enums.py
+++ b/rlapi/enums.py
@@ -50,7 +50,7 @@ class PlaylistKey(IntEnum):
 
 
 class Platform(Enum):
-    """Represents platform name.
+    """Represents player's platform.
 
     .. container:: operations
 
@@ -58,17 +58,25 @@ class Platform(Enum):
             Returns platform's friendly name, e.g. "Xbox One"
     """
 
-    value: str
     #: The Steam platform.
     steam = "Steam"
     #: The Playstation 4 platform.
-    ps4 = "Playstation 4"
+    ps4 = "PS4"
     #: The Xbox One platform.
-    xboxone = "Xbox One"
+    xboxone = "XboxOne"
     #: The Epic Games platform.
-    epic = "Epic Games"
+    epic = "Epic"
     #: The Nintendo Switch platform.
-    switch = "Nintendo Switch"
+    switch = "Switch"
 
     def __str__(self) -> str:
-        return self.value
+        return _PLATFORM_FRIENDLY_NAMES[self]
+
+
+_PLATFORM_FRIENDLY_NAMES = {
+    Platform.steam: "Steam",
+    Platform.ps4: "Playstation 4",
+    Platform.xboxone: "Xbox One",
+    Platform.epic: "Epic Games",
+    Platform.switch: "Nintendo Switch",
+}

--- a/rlapi/player.py
+++ b/rlapi/player.py
@@ -184,12 +184,8 @@ class SeasonRewards:
     __slots__ = ("level", "wins", "can_advance")
 
     def __init__(self, *, highest_tier: int = 0, data: Dict[str, Any]) -> None:
-        self.level: int = data.get("level", 0)
-        if self.level is None:
-            self.level = 0
-        self.wins: int = data.get("wins", 0)
-        if self.wins is None:
-            self.wins = 0
+        self.level: int = data.get("level") or 0
+        self.wins: int = data.get("wins") or 0
         self.can_advance: bool
         if self.level == 0 or self.level * 3 < highest_tier:
             self.can_advance = True
@@ -217,9 +213,11 @@ class Player:
     player_id: str
         ``player_id`` as passed to `Client.get_player()`.
     user_id: str, optional
-        Player's user ID, ``None`` for non-Steam players.
-    user_name: str
-        Player's username (display name)
+        Player's user ID.
+        Only present for Steam and Epic Games players.
+    user_name: str, optional
+        Player's username (display name).
+        Only present for Playstation 4, Xbox One, and Nintendo Switch players.
     playlists: dict
         Dictionary mapping `PlaylistKey` with `Playlist`.
     tier_breakdown: dict
@@ -253,8 +251,8 @@ class Player:
     ) -> None:
         self.platform = platform
         self.player_id = player_id
-        self.user_id: Optional[str] = data.get("user_id")
-        self.user_name: str = data["user_name"]
+        self.user_id: Optional[str] = data.get("player_id")
+        self.user_name: Optional[str] = data.get("player_name")
 
         self.playlists: Dict[Union[PlaylistKey, int], Playlist] = {}
         player_skills = data.get("player_skills", [])

--- a/rlapi/player.py
+++ b/rlapi/player.py
@@ -13,11 +13,17 @@
 # limitations under the License.
 
 import contextlib
+import sys
 from typing import Any, Dict, List, Optional, Union
 
 from .enums import Platform, PlaylistKey
 from .tier_estimates import TierEstimates
 from .typedefs import PlaylistBreakdownType, TierBreakdownType
+
+if sys.version_info[:2] >= (3, 8):
+    from typing import Final
+else:
+    from typing_extensions import Final
 
 RANKS = (
     "Unranked",
@@ -86,14 +92,14 @@ class Playlist:
         Win streak on this playlist.
     matches_played: int
         Amount of matches played on this playlist.
-    tier_max: int
-        Maximum tier that can be achieved on this playlist.
     breakdown: dict
         Playlist tier breakdown.
     tier_estimates: `TierEstimates`
         Tier estimates for this playlist.
 
     """
+
+    TIER_MAX: Final[int] = 22
 
     __slots__ = (
         "key",
@@ -104,7 +110,6 @@ class Playlist:
         "sigma",
         "win_streak",
         "matches_played",
-        "tier_max",
         "breakdown",
         "tier_estimates",
     )
@@ -137,18 +142,12 @@ class Playlist:
         self.sigma: float = data.get("sigma") or 8.333
         self.win_streak: int = data.get("win_streak") or 0
         self.matches_played: int = data.get("matches_played") or 0
-        self.tier_max = 22
-        # This is how it should be done, but API returns old max value right now
-        # While I could just have what API returns here,
-        # some parts of library depend on this being the proper value
-        #
-        # self.tier_max: int = data.get("tier_max", 22)
         self.breakdown = breakdown if breakdown is not None else {}
         self.tier_estimates = TierEstimates(self)
 
     def __str__(self) -> str:
         try:
-            if self.tier in {0, self.tier_max}:
+            if self.tier in {0, self.TIER_MAX}:
                 return RANKS[self.tier]
             return f"{RANKS[self.tier]} Div {DIVISIONS[self.division]}"
         except IndexError:

--- a/rlapi/tier_estimates.py
+++ b/rlapi/tier_estimates.py
@@ -104,7 +104,7 @@ class TierEstimates:
 
     def _estimate_div_up(self) -> Optional[int]:
         playlist = self.playlist
-        if self.tier == playlist.tier_max or self.tier == 0:
+        if self.tier == playlist.TIER_MAX or self.tier == 0:
             return None
         try:
             divisions = playlist.breakdown[self.tier]
@@ -136,7 +136,7 @@ class TierEstimates:
 
     def _estimate_tier_up(self) -> Optional[int]:
         playlist = self.playlist
-        if self.tier in {0, playlist.tier_max}:
+        if self.tier in {0, playlist.TIER_MAX}:
             return None
         try:
             divisions = playlist.breakdown[self.tier]
@@ -180,8 +180,8 @@ class TierEstimates:
         elif lowest_diff_division == 4:
             self.tier = lowest_diff_tier + 1
             self.division = 0
-            if self.tier > playlist.tier_max:
-                self.tier = playlist.tier_max
+            if self.tier > playlist.TIER_MAX:
+                self.tier = playlist.TIER_MAX
         else:
             self.tier = lowest_diff_tier
             self.division = lowest_diff_division


### PR DESCRIPTION
BREAKING CHANGE:
- Removed `Playlist.tier_max` instance attribute
- `platform.value` is now no longer the same as `str(platform)`
- The library is now using the new Rocket League API which
  requires a client ID and secret from Epic Games Developer Portal,
  instead of the old token.
  As a result, following breaking changes have been made:
    - `Client` now has 2 required keyword arguments `client_id`
      and `client_secret` instead of `token`.
    - `Client.change_token()` has been removed in favor of
      `Client.update_client_credentials()`
- `Client.get_player()` for Epic Games platform now requires
  Epic Account ID, instead of Epic Display Name.
  This is a limitation of the new API.
- `Player.user_name` is now only present for PlayStation 4, Xbox One,
  and Nintendo Switch players.
  This change corresponds to the platforms for which
  the player lookup requires the player's user name.
- `Player.user_id` is now present for Steam *and* Epic Games players.
  This change corresponds to the platforms for which
  the player lookup requires the player's user ID.